### PR TITLE
Do not define default resource config

### DIFF
--- a/charts/keycloak-realm-operator/Chart.yaml
+++ b/charts/keycloak-realm-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: keycloak-realm-operator
 description: A k8s operator to manage Keycloak realms, their config and clients
 type: application
-version: 0.0.32
+version: 0.0.33
 appVersion: 0.0.22

--- a/charts/keycloak-realm-operator/templates/operator-deployment.yaml
+++ b/charts/keycloak-realm-operator/templates/operator-deployment.yaml
@@ -31,13 +31,7 @@ spec:
             value: redis://operator-redis-svc:6379
           - name: DENO_CERT
             value: /kube-root-ca.crt
-        resources:
-          requests:
-            cpu: {{ .Values.resources.requests.cpu }}
-            memory: {{ .Values.resources.requests.memory }}
-          limits:
-            cpu: {{ .Values.resources.limits.cpu }}
-            memory: {{ .Values.resources.limits.memory }}
+        resources: {{- toYaml .Values.resources | nindent 10 }}
         volumeMounts:
         - name: kube-root-ca
           mountPath: /kube-root-ca.crt

--- a/charts/keycloak-realm-operator/values.yaml
+++ b/charts/keycloak-realm-operator/values.yaml
@@ -2,13 +2,14 @@ keycloak:
   url:
   username: {}
   password: {}
-resources:
-  requests:
-    cpu: 50m
-    memory: 256Mi
-  limits:
-    cpu: 100m
-    memory: 512Mi
+resources: {}
+# These resource values are just a suggestion, please adjust them to your needs
+#  requests:
+#    cpu: 50m
+#    memory: 256Mi
+#  limits:
+#    cpu: 100m
+#    memory: 512Mi
 genericCrds:
   - kind: KeycloakClientScope
     plural: keycloakclientscopes


### PR DESCRIPTION
Adding default resources makes it harder for users to override and there's a very high chance whatever we set here is wrong for a users' cluster anyways. 

Setting a CPU limit is also not great -> causes throttling and slowness.